### PR TITLE
Update Streamlit to v1.46.0 and use st.page_link

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,13 +18,10 @@ st.set_page_config(
 def main() -> None:
     st.write("# Welcome to The Trading Dashboard")
 
-    st.markdown(
-        '''
-        - 🚀 Co-Pilot
-        - 💡 Idea Generation
-        - 🚦 Due Diligence
-        '''
-    )
+    st.page_link("pages/3_💰_portfolio_analysis.py", label="🚀 Co-Pilot", use_container_width=True)
+    st.page_link("pages/1_📈_stocks_to_trade.py", label="💡 Idea Generation", use_container_width=True)
+    st.page_link("pages/4_🤯_surprises.py", label="🚦 Due Diligence", use_container_width=True)
+    st.markdown("---") # Add a separator
 
     info = pd.read_csv('./data/info.csv')
     #st.dataframe(info)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=2.2.4
 pandas>=2.2.3
 plotly>=5.24.1
-streamlit>=1.44.1
+streamlit>=1.46.0
 transformers>=4.48.0
 openpyxl
 numba>=0.57.1


### PR DESCRIPTION
- Updated requirements.txt to streamlit>=1.46.0.
- Replaced markdown navigation links in main.py with st.page_link.
- Verified that no deprecated experimental features were in use that needed replacement for this version upgrade.