### PR TITLE
Jules PR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,9 @@ numpy>=2.2.4
 pandas>=2.2.3
 plotly>=5.24.1
 streamlit>=1.46.0
-transformers>=4.48.0
-openpyxl
-numba>=0.57.1
-pyarrow>=14.0.1
-yfinance>=0.2.36
-scipy>=1.12.0  # Required for some statistical calculations
-#tensorflow
+# transformers>=4.48.0 # Code using this is commented out
+openpyxl # Kept as it's likely used by pandas for .xlsx files
+# numba>=0.57.1 # No direct usage found
+pyarrow>=14.0.1 # Required by streamlit
+# yfinance>=0.2.36 # No direct usage found
+# scipy>=1.12.0  # Required for some statistical calculations - Commenting out as no direct usage found


### PR DESCRIPTION
Refactor: Remove unused dependencies from requirements.txt

Removed scipy, numba, yfinance, and transformers from requirements.txt as they were not found to be directly used in the codebase.

- scipy, numba, yfinance: No direct imports or usage found.
- transformers: Code relying on this library was commented out.

Pyarrow was initially commented out but then reinstated as it is a core dependency of Streamlit.

Note: The project currently lacks runnable automated tests. Manual testing of all application functionalities is highly recommended to ensure these changes have not introduced any regressions.

---
*PR created automatically by Jules for task [12169628989099559066](https://jules.google.com/task/12169628989099559066) started by @hirawatt*