### PR TITLE
Jules PR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyarrow>=14.0.1
 yfinance>=0.2.36
 scipy>=1.12.0  # Required for some statistical calculations
 #tensorflow
+pytest

--- a/tests/test_main_app.py
+++ b/tests/test_main_app.py
@@ -1,0 +1,29 @@
+"""Tests for the main Streamlit application."""
+
+from streamlit.testing.v1 import AppTest
+
+def test_smoke_main_app():
+    """Basic smoke test to ensure the main app loads without exceptions."""
+    at = AppTest.from_file("main.py", default_timeout=30) # Increased timeout for potentially slower CI environments
+    at.run()
+    assert not at.exception, f"App raised an exception during run: {at.exception}"
+
+def test_main_app_elements():
+    """Test for the presence of key elements on the main page."""
+    at = AppTest.from_file("main.py", default_timeout=30)
+    at.run()
+    assert not at.exception, f"App raised an exception during run: {at.exception}"
+
+    # Test for the title
+    assert at.markdown[0].value == "# Welcome to The Trading Dashboard"
+
+    # Page link assertions are removed due to AppTest limitations with st.page_link rendering as UnknownElement.
+    # We can confirm the app runs and other elements are present.
+    # Future: If AppTest enhances st.page_link support, these tests can be added.
+
+    # Test for DATA.md content (check for a unique snippet)
+    # DATA.md content is the last markdown element added by st.write(Path("DATA.md").read_text())
+    # The title is markdown[0], separator is markdown[1]. So DATA.md should be markdown[2].
+    # Using -1 is also robust if no other markdown is added later.
+    assert "India Life Expectancy" in at.markdown[-1].value
+    assert "[macrotrends.net](https://www.macrotrends.net/countries/IND/india/life-expectancy)" in at.markdown[-1].value


### PR DESCRIPTION
feat: Add initial Streamlit app tests for main.py

- Installs pytest and adds it to requirements.txt.
- Creates test_main_app.py with AppTest.
- Adds a smoke test to ensure main.py loads.
- Adds tests for the main page title and DATA.md content.
- Page link assertions were removed due to current AppTest limitations
  where st.page_link renders as UnknownElement, making direct content
  assertion difficult.
- Leaves existing tests/test_symbol_check.py as is, per user preference.

---
*PR created automatically by Jules for task [8096786639098541372](https://jules.google.com/task/8096786639098541372) started by @hirawatt*